### PR TITLE
Remap comint commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Using python-MLS is as simple as entering the first of a multi-line statement at
 
 # Keys
 
-- `Up`/`Down` (or `C-p`/`C-n`): when on the last line in that direction, navigate history, otherwise move _within_ multi-line statements. 
+- `Up`/`Down` (or `M-p`/`M-n`): when on the last line in that direction, navigate history, otherwise move _within_ multi-line statements. 
 -  `S-Up`/`S-Down` (or `C-S-p`/`C-S-n`): skip through multi-line statements in command history without navigating inside them.
 - `S-Ret` or `M-Ret`: send a multi-line statement from anywhere within it.
 -  Two blank lines at statement end: send the multi-line statement.

--- a/python-mls.el
+++ b/python-mls.el
@@ -414,8 +414,8 @@ Kill buffer when PROCESS completes on EVENT."
   (let ((map (make-sparse-keymap)))
     (define-key map [(meta return)] #'python-mls-send-input)
     (define-key map [(shift return)] #'python-mls-send-input)
-    (define-key map [remap previous-line] #'python-mls-up-or-history)
-    (define-key map [remap next-line] #'python-mls-down-or-history)
+    (define-key map [remap comint-previous-input] #'python-mls-up-or-history)
+    (define-key map [remap comint-next-input] #'python-mls-down-or-history)
     (define-key map [remap comint-send-input]
       #'python-mls-continue-or-send-input)
     (define-key map [remap python-shell-completion-complete-or-indent]


### PR DESCRIPTION
Since the default commands for browsing histories are <kbd>M-p</kbd> and <kbd>M-p</kbd> bound in `comint-mode-map`. I think we should remap those commands instead to keep `previous-line` and `next-line` available as default. Users may bind <kbd>C-p</kbd> and <kbd>C-n</kbd> if they prefer them.